### PR TITLE
Options for SMILES and output file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Multiple chemical names can be retrieved simultaneously as such:
 
     ./molget water thf dmso dmf
 
-There is also a help message that may be useful:
+There is also a help message that will should you all the options:
 
     ./molget -h

--- a/molget
+++ b/molget
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Original work by Jan Jensen (https://github.com/jensengroup/molget).
 # Rewritten by Felipe Schneider.
 #
@@ -57,10 +57,10 @@ for molecule in "$@"
     # A URL is then generated.
     url="https://cactus.nci.nih.gov/chemical/structure/${molecule}/${cactus_repr}"
     # Spaces in the URL should be escaped.
-    url=$(echo "$url" | sed 's/ /%20/g')
+    url=${url// /%20}
 
     # It is also wise to translate spaces in filenames to underscores.
-    molecule_wo_spaces=$(echo "$molecule" | sed 's/ /_/g')
+    molecule_wo_spaces=${molecule// /_}
 
     # After, file names are generated.
     ob_inp_file="${molecule_wo_spaces}.${ob_inp_type}"

--- a/molget
+++ b/molget
@@ -108,6 +108,9 @@ for molecule in "$@"
       fi
     fi
 
-    obabel -i "$ob_inp_type" "$ob_inp_file" -o "$ob_out_type" -O "$ob_out_file" $ob_ext_opts 2> /dev/null
+    # Avoid cases in which the output file type is the same as the input one.
+    if [ "$ob_inp_type" != "$ob_out_type" ]; then
+      obabel -i "$ob_inp_type" "$ob_inp_file" -o "$ob_out_type" -O "$ob_out_file" $ob_ext_opts 2> /dev/null
+    fi
     echo " SUCCESS"
   done

--- a/molget
+++ b/molget
@@ -70,9 +70,9 @@ for molecule in "$@"
     curl -# "$url" -o "$ob_inp_file" 2> /dev/null
 
     # Check for 404 error
-    if grep -q "Page not found" "$molecule_wo_spaces.sdf"; then
+    if grep -q "Page not found" "${ob_inp_file}"; then
         echo " FAILED"
-        rm $molecule_wo_spaces.sdf
+        rm "${ob_inp_file}"
         continue
     fi
 

--- a/molget
+++ b/molget
@@ -48,14 +48,26 @@ for molecule in "$@"
   do
     echo -n $molecule
 
-    url="https://cactus.nci.nih.gov/chemical/structure/$molecule/sdf"
+    # Some preferences are preset, such as file types and options.
+    cactus_repr="sdf"
+    ob_inp_type="sdf"
+    ob_out_type="xyz"
+    ob_ext_opts="-c"
+
+    # A URL is then generated.
+    url="https://cactus.nci.nih.gov/chemical/structure/${molecule}/${cactus_repr}"
     # Spaces in the URL should be escaped.
     url=$(echo "$url" | sed 's/ /%20/g')
 
     # It is also wise to translate spaces in filenames to underscores.
     molecule_wo_spaces=$(echo "$molecule" | sed 's/ /_/g')
 
-    curl "$url" -o "$molecule_wo_spaces.sdf" 2> /dev/null
+    # After, file names are generated.
+    ob_inp_file="${molecule_wo_spaces}.${ob_inp_type}"
+    ob_out_file="${molecule_wo_spaces}.${ob_out_type}"
+
+    # The data is downloaded and transformed.
+    curl -# "$url" -o "$ob_inp_file" 2> /dev/null
 
     # Check for 404 error
     if grep -q "Page not found" "$molecule_wo_spaces.sdf"; then
@@ -64,6 +76,6 @@ for molecule in "$@"
         continue
     fi
 
-    obabel -isdf "$molecule_wo_spaces.sdf" -oxyz -O "$molecule_wo_spaces.xyz" -c 2> /dev/null
+    obabel -i "$ob_inp_type" "$ob_inp_file" -o "$ob_out_type" -O "$ob_out_file" $ob_ext_opts 2> /dev/null
     echo " SUCCESS"
   done

--- a/molget
+++ b/molget
@@ -46,7 +46,7 @@ shift $((OPTIND-1))
 
 for molecule in "$@"
   do
-    echo -n $molecule
+    echo -n "$molecule"
 
     # Some preferences are preset, such as file types and options.
     cactus_repr="sdf"

--- a/molget
+++ b/molget
@@ -2,7 +2,7 @@
 # Original work by Jan Jensen (https://github.com/jensengroup/molget).
 # Rewritten by Felipe Schneider.
 #
-#? molget 0.2
+#? molget 0.3
 #?
 #? Molget: bash script to get coordinates from chemical name using Cactus.
 #?

--- a/molget
+++ b/molget
@@ -10,6 +10,7 @@
 #?
 #?   -h  show this message
 #?   -v  show version
+#?   -s  assume chemical_name is a SMILES string
 #?
 #? Examples:
 #?
@@ -17,9 +18,12 @@
 #?   ./molget hexacyanoiron
 #?   ./molget water thf dmso dmf
 #?   ./molget "propylene carbonate"
+#?   ./molget -s "C(=O)N"
 #?   (remember to "chmod 755 molget")
 
-while getopts ":hv" opt "$@"
+use_smiles=false
+
+while getopts ":hvs" opt "$@"
   do
     case $opt in
       h)  # Help message.
@@ -29,6 +33,9 @@ while getopts ":hv" opt "$@"
       v)  # Version message.
         grep "^#? molget" "$0" | cut -c 4-
         exit 0
+        ;;
+      s)  # Use SMILES.
+        use_smiles=true
         ;;
       \?)
         echo "Invalid option: -$OPTARG" >&2
@@ -54,10 +61,12 @@ for molecule in "$@"
     ob_out_type="xyz"
     ob_ext_opts="-c"
 
-    # A URL is then generated.
-    url="https://cactus.nci.nih.gov/chemical/structure/${molecule}/${cactus_repr}"
-    # Spaces in the URL should be escaped.
-    url=${url// /%20}
+    if [ "$use_smiles" = true ]; then
+      # We need to change the input type.
+      ob_inp_type="smi"
+      # We also need to tell OpenBabel to generate 3D coordinates from SMILES.
+      ob_ext_opts="${ob_ext_opts} --gen3d"
+    fi
 
     # It is also wise to translate spaces in filenames to underscores.
     molecule_wo_spaces=${molecule// /_}
@@ -66,14 +75,24 @@ for molecule in "$@"
     ob_inp_file="${molecule_wo_spaces}.${ob_inp_type}"
     ob_out_file="${molecule_wo_spaces}.${ob_out_type}"
 
-    # The data is downloaded and transformed.
-    curl -# "$url" -o "$ob_inp_file" 2> /dev/null
+    # Now we need to generate the input file for OpenBabel.
+    if [ "$use_smiles" = true ]; then
+      echo "$molecule" > "$ob_inp_file"
+    else
+      # A URL is then generated.
+      url="https://cactus.nci.nih.gov/chemical/structure/${molecule}/${cactus_repr}"
+      # Spaces in the URL should be escaped.
+      url=${url// /%20}
 
-    # Check for 404 error
-    if grep -q "Page not found" "${ob_inp_file}"; then
-        echo " FAILED"
-        rm "${ob_inp_file}"
-        continue
+      # The data is downloaded and transformed.
+      curl -# "$url" -o "$ob_inp_file" 2> /dev/null
+
+      # Check for 404 error
+      if grep -q "Page not found" "${ob_inp_file}"; then
+          echo " FAILED"
+          rm "${ob_inp_file}"
+          continue
+      fi
     fi
 
     obabel -i "$ob_inp_type" "$ob_inp_file" -o "$ob_out_type" -O "$ob_out_file" $ob_ext_opts 2> /dev/null

--- a/molget
+++ b/molget
@@ -19,6 +19,7 @@
 #?   ./molget water thf dmso dmf
 #?   ./molget "propylene carbonate"
 #?   ./molget -s "C(=O)N"
+#?   ./molget -s "C/C=C\C" "C/C=C/C"
 #?   (remember to "chmod 755 molget")
 
 use_smiles=false
@@ -70,6 +71,10 @@ for molecule in "$@"
 
     # It is also wise to translate spaces in filenames to underscores.
     molecule_wo_spaces=${molecule// /_}
+
+    # Slashes should be escaped in Linux, backslashes in Windows/Wine.
+    molecule_wo_spaces=${molecule_wo_spaces//\//slash}
+    molecule_wo_spaces=${molecule_wo_spaces//\\/backslash}
 
     # After, file names are generated.
     ob_inp_file="${molecule_wo_spaces}.${ob_inp_type}"

--- a/molget
+++ b/molget
@@ -8,9 +8,11 @@
 #?
 #? Usage: molget chemical_name [chemical_name...]
 #?
-#?   -h  show this message
-#?   -v  show version
-#?   -s  assume chemical_name is a SMILES string
+#?   -h         show this message
+#?   -v         show version
+#?   -s         assume chemical_name is a SMILES string
+#?   -o [TYPE]  selects an output file type supported by OpenBabel (defaults to
+#?              xyz)
 #?
 #? Examples:
 #?
@@ -20,11 +22,15 @@
 #?   ./molget "propylene carbonate"
 #?   ./molget -s "C(=O)N"
 #?   ./molget -s "C/C=C\C" "C/C=C/C"
+#?   ./molget -o gamin p-nitrobenzene
+#?   ./molget -o pdb nadh nad+
+#?   ./molget -o gamin -s "C#C"
 #?   (remember to "chmod 755 molget")
 
 use_smiles=false
+ob_out_type="xyz"
 
-while getopts ":hvs" opt "$@"
+while getopts ":hvso:" opt "$@"
   do
     case $opt in
       h)  # Help message.
@@ -37,6 +43,9 @@ while getopts ":hvs" opt "$@"
         ;;
       s)  # Use SMILES.
         use_smiles=true
+        ;;
+      o)  # Set output type.
+        ob_out_type=$OPTARG
         ;;
       \?)
         echo "Invalid option: -$OPTARG" >&2
@@ -59,7 +68,6 @@ for molecule in "$@"
     # Some preferences are preset, such as file types and options.
     cactus_repr="sdf"
     ob_inp_type="sdf"
-    ob_out_type="xyz"
     ob_ext_opts="-c"
 
     if [ "$use_smiles" = true ]; then


### PR DESCRIPTION
In this PR two new options are added:
- a new option (`-s`) for reading SMILES strings instead of chemical names;
- a new option (`-o [TYPE]`) for selecting an alternative output file type supported by OpenBabel;

Some use of specific Bash capabilities is also put in place, which should not be a problem since the `-n` option of `echo`  (non-POSIX) was already being used anyway.

Things such as the following are now possible:

```
$ ./molget -o gamin p-nitrobenzene # generates GAMESS input
$ ./molget -o pdb nadh nad+ # two PDB files for each NADH and NAD+
$ ./molget -s "CCO" # XYZ for ethanol
$ ./molget -o adf -s "CCO" # ADF input for ethanol
```

I hope this is useful :)
